### PR TITLE
Long Format Tables for the Codepoint (character) table

### DIFF
--- a/templates/decode/character.html
+++ b/templates/decode/character.html
@@ -13,7 +13,7 @@
 </div>
 <br>
 <h5 class="header center green-text text-darken-2">Character Data</h5>
-<table class="responsive-table highlight">
+<table class="highlight">
   <tbody>
     <tr>
       <td>Name:</td>

--- a/templates/decode/character.html
+++ b/templates/decode/character.html
@@ -14,52 +14,52 @@
 <br>
 <h5 class="header center green-text text-darken-2">Character Data</h5>
 <table class="highlight">
-  <tbody>
+  <thead>
     <tr>
-      <td>Name:</td>
+      <th>Name:</th>
       <td>{{ name }}</td>
     </tr>
     <tr>
-      <td>Character:</td>
+      <th>Character:</th>
       <td>{{ char }}</td>
     </tr>
     <tr>
-      <td>Category:</td>
+      <th>Category:</th>
       <td>{{ category }}</td>
     </tr>
     <tr>
-      <td>Digit:</td>
+      <th>Digit:</th>
       <td>{{ digit }}</td>
     </tr>
     <tr>
-      <td>Direction:</td>
+      <th>Direction:</th>
       <td>{{ direction }}</td>
     </tr>
     <tr>
-      <td>Decomposition:</td>
+      <th>Decomposition:</th>
       <td>{{ decomposition }}</td>
     </tr>
     <tr>
-      <td>Integer:</td>
+      <th>Integer:</th>
       <td>{{ integer }}</td>
     </tr>
     <tr>
-      <td>Lower:</td>
+      <th>Lower:</th>
       <td>{{ lower }}</td>
     </tr>
     <tr>
-      <td>Upper:</td>
+      <th>Upper:</th>
       <td>{{ upper }}</td>
     </tr>
     <tr>
-      <td>Aliases:</td>
+      <th>Aliases:</th>
       <td>{{ aliases }}</td>
     </tr>
     <tr>
-      <td>East Asian Width:</td>
+      <th>East Asian Width:</th>
       <td>{{ east_asian }}</td>
     </tr>
-  </tbody>
+  </thead>
 </table>
 
 

--- a/templates/decode/decode.html
+++ b/templates/decode/decode.html
@@ -13,13 +13,18 @@
     </div>
 
     <table class="responsive-table highlight">
-        <th>Character</th>
-        <th>Name</th>
-        <th>Category</th>
-        <th>Digit</th>
-        <th>Direction</th>
-        <th>Integer</th>
-        <th>Code Point</th>
+        <thead>
+          <tr>
+            <th>Character</th>
+            <th>Name</th>
+            <th>Category</th>
+            <th>Digit</th>
+            <th>Direction</th>
+            <th>Integer</th>
+            <th>Code Point</th>
+          </tr>
+        </thead>
+        <tbody>
         {% for x in text %}
             <tr>
                 <td>{{x.char}}</td>
@@ -29,8 +34,9 @@
                 <td>{{x.bidi}}</td>
                 <td>{{x.ord}}</td>
                 <td>{{x.code_point}}</td>
-        </tr>
+            </tr>
         {% endfor %}
+        </tbody>
     </table>
 <br>
     <div class="row">

--- a/templates/decode/tofu.html
+++ b/templates/decode/tofu.html
@@ -16,7 +16,7 @@
 
 
       <table class="responsive-table highlight">
-        <tbody>
+        <thead>
           <tr>
             <th>Character</th>
             <th>Name</th>
@@ -26,6 +26,8 @@
             <th>Integer</th>
             <th>Code Point</th>
           </tr>
+        </thead>
+        <tbody>
           <tr>
             <td>𐓇</td>
             <td>OSAGE CAPITAL LETTER SHA</td>


### PR DESCRIPTION
Ticket: [Tables flip diagonally on narrow screens / bad usage of Responsive Table ](https://github.com/danieljdorado/unicodedecode/issues/42)

## Description

There were a few issues with tables.  
1. On mobile devices a codepoint page would become a wide format which is difficult to read
2. Sematics were were incorrect so headers didn't come out bolded. 
3. Headers should've been the thead class