### PR TITLE
Upgrade to Unicode 17.0.0

### DIFF
--- a/context_processors.py
+++ b/context_processors.py
@@ -1,0 +1,8 @@
+"""Template context processors for the decode app."""
+
+import unicodedata2
+
+
+def unicode_version(request):
+    """Add Unicode data version from unicodedata2 to every template context."""
+    return {'unicode_version': unicodedata2.unidata_version}

--- a/files/NameAliases.txt
+++ b/files/NameAliases.txt
@@ -1,10 +1,11 @@
-# NameAliases-12.1.0.txt
-# Date: 2019-03-08, 23:59:00 GMT [KW, LI]
-# © 2019 Unicode®, Inc.
-# For terms of use, see http://www.unicode.org/terms_of_use.html
+# NameAliases-17.0.0.txt
+# Date: 2025-04-23
+# © 2025 Unicode®, Inc.
+# Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+# For terms of use and license, see https://www.unicode.org/terms_of_use.html
 #
 # Unicode Character Database
-# For documentation, see http://www.unicode.org/reports/tr44/
+# For documentation, see https://www.unicode.org/reports/tr44/
 #
 # This file is a normative contributory data file in the
 # Unicode Character Database.
@@ -40,7 +41,7 @@
 # control codes (which for historical reasons have no Unicode character name)
 # or for format characters.
 #
-# For documentation, see NamesList.html and http://www.unicode.org/reports/tr44/
+# For documentation, see NamesList.html and https://www.unicode.org/reports/tr44/
 #
 # FORMAT
 #
@@ -135,6 +136,7 @@
 0018;CAN;abbreviation
 0019;END OF MEDIUM;control
 0019;EOM;abbreviation
+0019;EM;abbreviation
 001A;SUBSTITUTE;control
 001A;SUB;abbreviation
 001B;ESCAPE;control
@@ -163,7 +165,7 @@
 # (and corresponding abbreviations) for these code
 # points are included here because these names leaked
 # out from the draft documents and were published in
-# at least one RFC whose names for code points was
+# at least one RFC whose names for code points were
 # implemented in Perl regex expressions.
 
 0080;PADDING CHARACTER;figment
@@ -254,6 +256,7 @@
 01A2;LATIN CAPITAL LETTER GHA;correction
 01A3;LATIN SMALL LETTER GHA;correction
 034F;CGJ;abbreviation
+0616;ARABIC SMALL HIGH LIGATURE ALEF WITH YEH BARREE;correction
 061C;ALM;abbreviation
 0709;SYRIAC SUBLINEAR COLON SKEWED LEFT;correction
 0CDE;KANNADA LETTER LLLA;correction
@@ -270,6 +273,8 @@
 180C;FVS2;abbreviation
 180D;FVS3;abbreviation
 180E;MVS;abbreviation
+180F;FVS4;abbreviation
+1BBD;SUNDANESE LETTER ARCHAIC I;correction
 200B;ZWSP;abbreviation
 200C;ZWNJ;abbreviation
 200D;ZWJ;abbreviation
@@ -293,6 +298,7 @@
 2B7A;LEFTWARDS TRIANGLE-HEADED ARROW WITH DOUBLE VERTICAL STROKE;correction
 2B7C;RIGHTWARDS TRIANGLE-HEADED ARROW WITH DOUBLE VERTICAL STROKE;correction
 A015;YI SYLLABLE ITERATION MARK;correction
+AA6E;MYANMAR LETTER KHAMTI LLA;correction
 FE00;VS1;abbreviation
 FE01;VS2;abbreviation
 FE02;VS3;abbreviation
@@ -315,12 +321,20 @@ FEFF;BOM;abbreviation
 FEFF;ZWNBSP;abbreviation
 122D4;CUNEIFORM SIGN NU11 TENU;correction
 122D5;CUNEIFORM SIGN NU11 OVER NU11 BUR OVER BUR;correction
+12327;CUNEIFORM SIGN KALAM;correction
+1680B;BAMUM LETTER PHASE-A MAEMGBIEE;correction
+16881;BAMUM LETTER PHASE-B PUNGGAAM;correction
+1688E;BAMUM LETTER PHASE-B NGGOM;correction
+168DC;BAMUM LETTER PHASE-C SHETFON;correction
+1697D;BAMUM LETTER PHASE-E NGGOP;correction
 16E56;MEDEFAIDRIN CAPITAL LETTER H;correction
 16E57;MEDEFAIDRIN CAPITAL LETTER NG;correction
 16E76;MEDEFAIDRIN SMALL LETTER H;correction
 16E77;MEDEFAIDRIN SMALL LETTER NG;correction
 1B001;HENTAIGANA LETTER E-1;correction
 1D0C5;BYZANTINE MUSICAL SYMBOL FTHORA SKLIRON CHROMA VASIS;correction
+1E899;MENDE KIKAKUI SYLLABLE M172 MBO;correction
+1E89A;MENDE KIKAKUI SYLLABLE M174 MBOO;correction
 E0100;VS17;abbreviation
 E0101;VS18;abbreviation
 E0102;VS19;abbreviation

--- a/templates/decode/footer.html
+++ b/templates/decode/footer.html
@@ -28,7 +28,7 @@
     </div>
     <div class="footer-copyright">
       <div class="container black-text">
-        <a class="green-text text-darken-2" href="http://materializecss.com">Materialize</a> Theme design by <a class="green-text text-darken-2" href="https://github.com/mcdonald-cyber">Cynthia McDonald</a> – Unicode Version: 12.1.0
+        <a class="green-text text-darken-2" href="http://materializecss.com">Materialize</a> Theme design by <a class="green-text text-darken-2" href="https://github.com/mcdonald-cyber">Cynthia McDonald</a> – Unicode Version: {{ unicode_version }}
       </div>
     </div>
   </footer>

--- a/tests.py
+++ b/tests.py
@@ -7,15 +7,11 @@ import decode.unicode_util as u
 
 
 class UnicodeVersionTestCase(TestCase):
-    """Check the footer template version."""
-    def setUp(self):
-        # Footer template unicode version.
-        # Update version manually in the template if tests fail.
-        self.unicode_version = "17.0.0"
-
-    def test_unicode_version_exact(self):
-        """Current unicode version matches expected for footer."""
-        self.assertEqual(ud.unidata_version, self.unicode_version)
+    """Check the footer template version comes from unicodedata2."""
+    def test_footer_shows_unicode_version(self):
+        """Footer displays current unicodedata2 version."""
+        response = self.client.get(reverse('decode'))
+        self.assertContains(response, ud.unidata_version)
 
     def test_unicode_version_format(self):
         """Unicode version string has expected x.y.z format."""

--- a/tests.py
+++ b/tests.py
@@ -2,7 +2,7 @@
 
 from django.test import TestCase, Client
 from django.urls import reverse
-import unicodedata as ud
+import unicodedata2 as ud
 import decode.unicode_util as u
 
 
@@ -11,7 +11,7 @@ class UnicodeVersionTestCase(TestCase):
     def setUp(self):
         # Footer template unicode version.
         # Update version manually in the template if tests fail.
-        self.unicode_version = "12.1.0"
+        self.unicode_version = "17.0.0"
 
     def test_unicode_version_exact(self):
         """Current unicode version matches expected for footer."""
@@ -44,7 +44,9 @@ class TestCodePoints(TestCase):
             'ש': 'U+05E9',   # HEBREW LETTER SHIN
             'ۻ': 'U+06FB',   # ARABIC LETTER DAD WITH DOT BELOW
             ' ': 'U+0020',   # SPACE
-            '😀': 'U+1F600',  # GRINNING FACE
+            '😀': 'U+1F600',   # GRINNING FACE
+            '🫪': 'U+1FAEA',    # DISTORTED FACE
+            '🫍': 'U+1FACD'   # ORCA
         }
 
     def test_get_code_point_with_prefix(self):
@@ -71,6 +73,130 @@ class TestCodePoints(TestCase):
         # U+1F600 GRINNING FACE
         self.assertEqual(u.get_code_point('😀', prefix=False), '1F600')
         self.assertEqual(u.get_code_point('😀', prefix=True), 'U+1F600')
+
+
+class TestIsNormalized(TestCase):
+    """Unit tests for is_normalized(form, s)."""
+
+    def test_empty_string_all_forms(self):
+        """Empty string is normalized in every form."""
+        for form in ('NFC', 'NFKC', 'NFD', 'NFKD'):
+            with self.subTest(form=form):
+                self.assertTrue(u.is_normalized(form, ''))
+
+    def test_ascii_all_forms(self):
+        """ASCII letters and digits are typically normalized in all forms."""
+        for s in ('a', 'Z', '0', '9', 'Hello', ' \t\n'):
+            with self.subTest(s=repr(s)):
+                for form in ('NFC', 'NFKC', 'NFD', 'NFKD'):
+                    self.assertTrue(u.is_normalized(form, s), f'{form} {repr(s)}')
+
+    def test_nfc_precomposed_is_nfc(self):
+        """Precomposed characters (single codepoint) are NFC."""
+        # é = U+00E9 (single precomposed char)
+        self.assertTrue(u.is_normalized('NFC', 'é'))
+        self.assertTrue(u.is_normalized('NFC', 'ñ'))
+        self.assertTrue(u.is_normalized('NFC', 'ü'))
+
+    def test_nfc_decomposed_is_not_nfc(self):
+        """Decomposed sequence (base + combining) is not NFC."""
+        # e + U+0301 COMBINING ACUTE
+        decomposed_e_acute = 'e\u0301'
+        self.assertFalse(u.is_normalized('NFC', decomposed_e_acute))
+        self.assertEqual(ud.normalize('NFC', decomposed_e_acute), 'é')
+
+    def test_nfd_decomposed_is_nfd(self):
+        """Decomposed sequence is NFD."""
+        decomposed_e_acute = 'e\u0301'
+        self.assertTrue(u.is_normalized('NFD', decomposed_e_acute))
+
+    def test_nfd_precomposed_is_not_nfd(self):
+        """Precomposed character is not NFD (decomposed form has multiple codepoints)."""
+        self.assertFalse(u.is_normalized('NFD', 'é'))
+        self.assertEqual(ud.normalize('NFD', 'é'), 'e\u0301')
+
+    def test_nfkc_compatibility_composite(self):
+        """Compatibility composite (e.g. ﬁ) is NFC but not NFKC."""
+        # U+FB01 LATIN SMALL LIGATURE FI
+        fi_ligature = '\uFB01'
+        self.assertTrue(u.is_normalized('NFC', fi_ligature))
+        self.assertFalse(u.is_normalized('NFKC', fi_ligature))
+        self.assertEqual(ud.normalize('NFKC', fi_ligature), 'fi')
+
+    def test_nfkc_after_normalize_is_normalized(self):
+        """String normalized to NFKC is is_normalized('NFKC', ...) True."""
+        fi_ligature = '\uFB01'
+        nfkc = ud.normalize('NFKC', fi_ligature)
+        self.assertTrue(u.is_normalized('NFKC', nfkc))
+
+    def test_nfkd_decomposed_compatibility(self):
+        """NFKD decomposes compatibility characters."""
+        fi_ligature = '\uFB01'
+        self.assertFalse(u.is_normalized('NFKD', fi_ligature))
+        nfkd = ud.normalize('NFKD', fi_ligature)
+        self.assertTrue(u.is_normalized('NFKD', nfkd))
+
+    def test_is_normalized_equals_normalize_equality(self):
+        """is_normalized(form, s) matches (s == ud.normalize(form, s))."""
+        cases = [
+            '',
+            'a',
+            'é',
+            'e\u0301',
+            '\uFB01',   # ﬁ
+            'ẛ\u0323',  # ẛ̣ (dot above + dot below)
+            'café',
+            'cafe\u0301',
+            '😀',
+            '2\u2075',   # 2⁵
+        ]
+        for s in cases:
+            for form in ('NFC', 'NFKC', 'NFD', 'NFKD'):
+                with self.subTest(form=form, s=repr(s)):
+                    expected = (s == ud.normalize(form, s))
+                    self.assertIs(u.is_normalized(form, s), expected)
+
+    def test_each_form_independently(self):
+        """Each form gives correct True/False for known strings."""
+        # (string, form, expected)
+        cases = [
+            ('é', 'NFC', True),
+            ('é', 'NFD', False),
+            ('e\u0301', 'NFC', False),
+            ('e\u0301', 'NFD', True),
+            ('\uFB01', 'NFC', True),
+            ('\uFB01', 'NFKC', False),
+            ('fi', 'NFKC', True),
+            ('ẛ\u0323', 'NFC', True),
+            ('ẛ\u0323', 'NFD', False),
+            ('ẛ\u0323', 'NFKD', False),
+        ]
+        for s, form, expected in cases:
+            with self.subTest(form=form, s=repr(s), expected=expected):
+                self.assertIs(u.is_normalized(form, s), expected)
+
+    def test_return_type_bool(self):
+        """is_normalized returns bool."""
+        self.assertIsInstance(u.is_normalized('NFC', ''), bool)
+        self.assertIsInstance(u.is_normalized('NFC', 'x'), bool)
+        self.assertIsInstance(u.is_normalized('NFD', 'é'), bool)
+
+    def test_multiple_combining_marks(self):
+        """Multiple combining marks: NFD string is normalized in NFD only when canonical."""
+        # a + acute + diaeresis (canonical order)
+        a_acute_diaeresis = 'a\u0301\u0308'
+        nfd = ud.normalize('NFD', a_acute_diaeresis)
+        self.assertTrue(u.is_normalized('NFD', nfd))
+        # If we had wrong order, might not be NFD
+        self.assertTrue(u.is_normalized('NFD', ud.normalize('NFD', 'ä\u0301')))
+
+    def test_emoji_supplementary_plane(self):
+        """Supplementary plane (e.g. emoji) can be NFC/NFD."""
+        emoji = '😀'
+        self.assertTrue(u.is_normalized('NFC', emoji))
+        self.assertTrue(u.is_normalized('NFD', emoji))
+        nfd_emoji = ud.normalize('NFD', emoji)
+        self.assertTrue(u.is_normalized('NFD', nfd_emoji))
 
 
 class TestNormalization(TestCase):

--- a/unicode_util.py
+++ b/unicode_util.py
@@ -6,7 +6,7 @@ bidirectional class, East Asian width, and aliases from the Unicode database.
 
 import os
 import re
-import unicodedata as ud
+import unicodedata2 as ud
 from decode.mappings import bidi, category, east_asian_categories
 
 # App package directory (decode/)
@@ -40,6 +40,19 @@ def examen_unicode(text):
 
 
 
+def is_normalized(form, s):
+    """Return whether the string is already in the given normalization form.
+
+    Args:
+        form: Unicode normalization form name ('NFC', 'NFKC', 'NFD', or 'NFKD').
+        s: Unicode string to check.
+
+    Returns:
+        True if s is normalized in that form, False otherwise.
+    """
+    return s == ud.normalize(form, s)
+
+
 def get_normalization_form(string):
     """Report which Unicode normalization forms the string is already in.
 
@@ -54,7 +67,7 @@ def get_normalization_form(string):
     normalization_form = {}
 
     for form in forms:
-        if ud.is_normalized(form, string):
+        if is_normalized(form, string):
             normalization_form[form] = True
         else:
             normalization_form[form] = False


### PR DESCRIPTION
## Description

A major leap forward. Upgrade from 12.1.0  to 17.0.0

## Implementation
* Use unicodedate2 rather than the python default
* Update version details to be updated dynamically.
* unicodedata2 doesn't have` is_normalized` so implement a local version. 

## Testing

<img width="640" height="916" alt="Screenshot 2026-02-15 at 12 44 47 PM" src="https://github.com/user-attachments/assets/a397d319-a1db-4d7f-a2bc-70198b215bad" />
