### PR TITLE
Python 3.14.3 and Code Clean Up

### DIFF
--- a/templates/decode/decode.html
+++ b/templates/decode/decode.html
@@ -30,11 +30,11 @@
             {% for x in text %}
                 <tr>
                     <td data-label="Character">{{ x.char|default:"N/A" }}</td>
-                    <td data-label="Name"><a href="{% url 'codepoint' slug=x.hex %}" class="green-text text-darken-2">{{ x.name|default:"N/A" }}</a></td>
+                    <td data-label="Name"><a href="{% url 'codepoint' slug=x.hex_code %}" class="green-text text-darken-2">{{ x.name|default:"N/A" }}</a></td>
                     <td data-label="Category">{{ x.category|default:"N/A" }}</td>
                     <td data-label="Digit">{{ x.digit|default:"N/A" }}</td>
                     <td data-label="Direction">{{ x.bidi|default:"N/A" }}</td>
-                    <td data-label="Integer">{{ x.ord|default:"N/A" }}</td>
+                    <td data-label="Integer">{{ x.ordinal|default:"N/A" }}</td>
                     <td data-label="Code Point">{{ x.code_point|default:"N/A" }}</td>
                 </tr>
             {% endfor %}

--- a/templates/decode/decode.html
+++ b/templates/decode/decode.html
@@ -50,14 +50,14 @@
             <thead>
               <tr>
                 {% for key in normalization_form.keys %}
-                <th>{{ key }}</th>
+                <th>{{ key.name }}</th>
                 {% endfor %}
               </tr>
             </thead>
             <tbody>
               <tr>
                 {% for key, item in normalization_form.items %}
-                <td data-label="{{ key }}">
+                <td data-label="{{ key.name }}">
                     {% if item == True %}
                         <span class="green-text text-darken-2">{{ item }}</span>
                     {% else %}

--- a/tests.py
+++ b/tests.py
@@ -70,6 +70,17 @@ class TestCodePoints(TestCase):
         self.assertEqual(u.get_code_point('😀', prefix=False), '1F600')
         self.assertEqual(u.get_code_point('😀', prefix=True), 'U+1F600')
 
+    def test_get_code_point_requires_single_character(self):
+        """get_code_point raises ValueError for empty or multi-character input."""
+        with self.assertRaises(ValueError) as cm:
+            u.get_code_point('')
+        self.assertIn('single character', str(cm.exception))
+        self.assertIn('length 0', str(cm.exception))
+        with self.assertRaises(ValueError) as cm:
+            u.get_code_point('ab')
+        self.assertIn('single character', str(cm.exception))
+        self.assertIn('length 2', str(cm.exception))
+
 
 class TestIsNormalized(TestCase):
     """Unit tests for is_normalized(form, s)."""

--- a/tests.py
+++ b/tests.py
@@ -336,9 +336,9 @@ class TestExamenUnicode(TestCase):
         self.assertEqual(len(result), 1)
         self.assertIsInstance(result[0], u.CharacterInfo)
         self.assertEqual(result[0].char, 'A')
-        self.assertEqual(result[0].ord, 65)
+        self.assertEqual(result[0].ordinal, 65)
         self.assertEqual(result[0].code_point, 'U+0041')
-        self.assertEqual(result[0].hex, '0041')
+        self.assertEqual(result[0].hex_code, '0041')
 
     def test_multiple_characters(self):
         """Multiple characters return one CharacterInfo per character."""

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,6 @@
 """Backend tests for decode app."""
 
+import dataclasses
 from django.test import TestCase, Client
 from django.urls import reverse
 import unicodedata2 as ud
@@ -401,23 +402,25 @@ class TestGetCharacterPageDescription(TestCase):
         'aliases', 'east_asian',
     }
 
-    def test_returns_all_keys(self):
-        """Returned dict has all keys needed by codepoint template."""
+    def test_returns_codepoint_description(self):
+        """Returned value is CodepointDescription with all fields needed by template."""
         desc = u.get_character_page_description('A')
-        self.assertEqual(set(desc.keys()), self.REQUIRED_KEYS)
+        self.assertIsInstance(desc, u.CodepointDescription)
+        field_names = {f.name for f in dataclasses.fields(desc)}
+        self.assertEqual(field_names, self.REQUIRED_KEYS)
 
     def test_values_sensible(self):
         """Values are correct types and consistent."""
         desc = u.get_character_page_description('a')
-        self.assertEqual(desc['char'], 'a')
-        self.assertEqual(desc['name'], 'LATIN SMALL LETTER A')
-        self.assertEqual(desc['tagline'], 'U+0061')
-        self.assertEqual(desc['integer'], 97)
-        self.assertEqual(desc['upper'], 'A')
-        self.assertEqual(desc['lower'], 'a')
-        self.assertIsInstance(desc['decomposition'], str)
-        self.assertIsInstance(desc['aliases'], str)
-        self.assertTrue(desc['east_asian'] is None or isinstance(desc['east_asian'], str))
+        self.assertEqual(desc.char, 'a')
+        self.assertEqual(desc.name, 'LATIN SMALL LETTER A')
+        self.assertEqual(desc.tagline, 'U+0061')
+        self.assertEqual(desc.integer, 97)
+        self.assertEqual(desc.upper, 'A')
+        self.assertEqual(desc.lower, 'a')
+        self.assertIsInstance(desc.decomposition, str)
+        self.assertIsInstance(desc.aliases, str)
+        self.assertTrue(desc.east_asian is None or isinstance(desc.east_asian, str))
 
 
 class DecodeViewTestCase(TestCase):

--- a/tests.py
+++ b/tests.py
@@ -76,7 +76,7 @@ class TestIsNormalized(TestCase):
 
     def test_empty_string_all_forms(self):
         """Empty string is normalized in every form."""
-        for form in ('NFC', 'NFKC', 'NFD', 'NFKD'):
+        for form in u.NormalizationForm:
             with self.subTest(form=form):
                 self.assertTrue(u.is_normalized(form, ''))
 
@@ -84,53 +84,53 @@ class TestIsNormalized(TestCase):
         """ASCII letters and digits are typically normalized in all forms."""
         for s in ('a', 'Z', '0', '9', 'Hello', ' \t\n'):
             with self.subTest(s=repr(s)):
-                for form in ('NFC', 'NFKC', 'NFD', 'NFKD'):
+                for form in u.NormalizationForm:
                     self.assertTrue(u.is_normalized(form, s), f'{form} {repr(s)}')
 
     def test_nfc_precomposed_is_nfc(self):
         """Precomposed characters (single codepoint) are NFC."""
         # é = U+00E9 (single precomposed char)
-        self.assertTrue(u.is_normalized('NFC', 'é'))
-        self.assertTrue(u.is_normalized('NFC', 'ñ'))
-        self.assertTrue(u.is_normalized('NFC', 'ü'))
+        self.assertTrue(u.is_normalized(u.NormalizationForm.NFC, 'é'))
+        self.assertTrue(u.is_normalized(u.NormalizationForm.NFC, 'ñ'))
+        self.assertTrue(u.is_normalized(u.NormalizationForm.NFC, 'ü'))
 
     def test_nfc_decomposed_is_not_nfc(self):
         """Decomposed sequence (base + combining) is not NFC."""
         # e + U+0301 COMBINING ACUTE
         decomposed_e_acute = 'e\u0301'
-        self.assertFalse(u.is_normalized('NFC', decomposed_e_acute))
+        self.assertFalse(u.is_normalized(u.NormalizationForm.NFC, decomposed_e_acute))
         self.assertEqual(ud.normalize('NFC', decomposed_e_acute), 'é')
 
     def test_nfd_decomposed_is_nfd(self):
         """Decomposed sequence is NFD."""
         decomposed_e_acute = 'e\u0301'
-        self.assertTrue(u.is_normalized('NFD', decomposed_e_acute))
+        self.assertTrue(u.is_normalized(u.NormalizationForm.NFD, decomposed_e_acute))
 
     def test_nfd_precomposed_is_not_nfd(self):
         """Precomposed character is not NFD (decomposed form has multiple codepoints)."""
-        self.assertFalse(u.is_normalized('NFD', 'é'))
+        self.assertFalse(u.is_normalized(u.NormalizationForm.NFD, 'é'))
         self.assertEqual(ud.normalize('NFD', 'é'), 'e\u0301')
 
     def test_nfkc_compatibility_composite(self):
         """Compatibility composite (e.g. ﬁ) is NFC but not NFKC."""
         # U+FB01 LATIN SMALL LIGATURE FI
         fi_ligature = '\uFB01'
-        self.assertTrue(u.is_normalized('NFC', fi_ligature))
-        self.assertFalse(u.is_normalized('NFKC', fi_ligature))
+        self.assertTrue(u.is_normalized(u.NormalizationForm.NFC, fi_ligature))
+        self.assertFalse(u.is_normalized(u.NormalizationForm.NFKC, fi_ligature))
         self.assertEqual(ud.normalize('NFKC', fi_ligature), 'fi')
 
     def test_nfkc_after_normalize_is_normalized(self):
         """String normalized to NFKC is is_normalized('NFKC', ...) True."""
         fi_ligature = '\uFB01'
         nfkc = ud.normalize('NFKC', fi_ligature)
-        self.assertTrue(u.is_normalized('NFKC', nfkc))
+        self.assertTrue(u.is_normalized(u.NormalizationForm.NFKC, nfkc))
 
     def test_nfkd_decomposed_compatibility(self):
         """NFKD decomposes compatibility characters."""
         fi_ligature = '\uFB01'
-        self.assertFalse(u.is_normalized('NFKD', fi_ligature))
+        self.assertFalse(u.is_normalized(u.NormalizationForm.NFKD, fi_ligature))
         nfkd = ud.normalize('NFKD', fi_ligature)
-        self.assertTrue(u.is_normalized('NFKD', nfkd))
+        self.assertTrue(u.is_normalized(u.NormalizationForm.NFKD, nfkd))
 
     def test_is_normalized_equals_normalize_equality(self):
         """is_normalized(form, s) matches (s == ud.normalize(form, s))."""
@@ -147,25 +147,25 @@ class TestIsNormalized(TestCase):
             '2\u2075',   # 2⁵
         ]
         for s in cases:
-            for form in ('NFC', 'NFKC', 'NFD', 'NFKD'):
+            for form in u.NormalizationForm:
                 with self.subTest(form=form, s=repr(s)):
-                    expected = (s == ud.normalize(form, s))
+                    expected = (s == ud.normalize(form.value, s))
                     self.assertIs(u.is_normalized(form, s), expected)
 
     def test_each_form_independently(self):
         """Each form gives correct True/False for known strings."""
         # (string, form, expected)
         cases = [
-            ('é', 'NFC', True),
-            ('é', 'NFD', False),
-            ('e\u0301', 'NFC', False),
-            ('e\u0301', 'NFD', True),
-            ('\uFB01', 'NFC', True),
-            ('\uFB01', 'NFKC', False),
-            ('fi', 'NFKC', True),
-            ('ẛ\u0323', 'NFC', True),
-            ('ẛ\u0323', 'NFD', False),
-            ('ẛ\u0323', 'NFKD', False),
+            ('é', u.NormalizationForm.NFC, True),
+            ('é', u.NormalizationForm.NFD, False),
+            ('e\u0301', u.NormalizationForm.NFC, False),
+            ('e\u0301', u.NormalizationForm.NFD, True),
+            ('\uFB01', u.NormalizationForm.NFC, True),
+            ('\uFB01', u.NormalizationForm.NFKC, False),
+            ('fi', u.NormalizationForm.NFKC, True),
+            ('ẛ\u0323', u.NormalizationForm.NFC, True),
+            ('ẛ\u0323', u.NormalizationForm.NFD, False),
+            ('ẛ\u0323', u.NormalizationForm.NFKD, False),
         ]
         for s, form, expected in cases:
             with self.subTest(form=form, s=repr(s), expected=expected):
@@ -173,37 +173,38 @@ class TestIsNormalized(TestCase):
 
     def test_return_type_bool(self):
         """is_normalized returns bool."""
-        self.assertIsInstance(u.is_normalized('NFC', ''), bool)
-        self.assertIsInstance(u.is_normalized('NFC', 'x'), bool)
-        self.assertIsInstance(u.is_normalized('NFD', 'é'), bool)
+        self.assertIsInstance(u.is_normalized(u.NormalizationForm.NFC, ''), bool)
+        self.assertIsInstance(u.is_normalized(u.NormalizationForm.NFC, 'x'), bool)
+        self.assertIsInstance(u.is_normalized(u.NormalizationForm.NFD, 'é'), bool)
 
     def test_multiple_combining_marks(self):
         """Multiple combining marks: NFD string is normalized in NFD only when canonical."""
         # a + acute + diaeresis (canonical order)
         a_acute_diaeresis = 'a\u0301\u0308'
         nfd = ud.normalize('NFD', a_acute_diaeresis)
-        self.assertTrue(u.is_normalized('NFD', nfd))
+        self.assertTrue(u.is_normalized(u.NormalizationForm.NFD, nfd))
         # If we had wrong order, might not be NFD
-        self.assertTrue(u.is_normalized('NFD', ud.normalize('NFD', 'ä\u0301')))
+        self.assertTrue(u.is_normalized(u.NormalizationForm.NFD, ud.normalize('NFD', 'ä\u0301')))
 
     def test_emoji_supplementary_plane(self):
         """Supplementary plane (e.g. emoji) can be NFC/NFD."""
         emoji = '😀'
-        self.assertTrue(u.is_normalized('NFC', emoji))
-        self.assertTrue(u.is_normalized('NFD', emoji))
+        self.assertTrue(u.is_normalized(u.NormalizationForm.NFC, emoji))
+        self.assertTrue(u.is_normalized(u.NormalizationForm.NFD, emoji))
         nfd_emoji = ud.normalize('NFD', emoji)
-        self.assertTrue(u.is_normalized('NFD', nfd_emoji))
+        self.assertTrue(u.is_normalized(u.NormalizationForm.NFD, nfd_emoji))
 
 
 class TestNormalization(TestCase):
     """Normalization form detection."""
     def setUp(self):
+        NF = u.NormalizationForm
         self.forms = {
-            'a': {'NFC': True, 'NFKC': True, 'NFD': True, 'NFKD': True},
-            'é': {'NFC': True, 'NFKC': True, 'NFD': False, 'NFKD': False},
-            'é': {'NFC': False, 'NFKC': False, 'NFD': True, 'NFKD': True},  # e + combining acute
-            'ﬁ': {'NFC': True, 'NFKC': False, 'NFD': True, 'NFKD': False},
-            'ẛ̣': {'NFC': True, 'NFKC': False, 'NFD': False, 'NFKD': False},
+            'a': {NF.NFC: True, NF.NFKC: True, NF.NFD: True, NF.NFKD: True},
+            'é': {NF.NFC: True, NF.NFKC: True, NF.NFD: False, NF.NFKD: False},
+            'é': {NF.NFC: False, NF.NFKC: False, NF.NFD: True, NF.NFKD: True},  # e + combining acute
+            'ﬁ': {NF.NFC: True, NF.NFKC: False, NF.NFD: True, NF.NFKD: False},
+            'ẛ̣': {NF.NFC: True, NF.NFKC: False, NF.NFD: False, NF.NFKD: False},
         }
 
     def test_normalization_check(self):
@@ -216,7 +217,7 @@ class TestNormalization(TestCase):
     def test_normalization_returns_all_forms(self):
         """get_normalization_form returns exactly NFC, NFKC, NFD, NFKD."""
         result = u.get_normalization_form('a')
-        self.assertEqual(set(result.keys()), {'NFC', 'NFKC', 'NFD', 'NFKD'})
+        self.assertEqual(set(result.keys()), set(u.NormalizationForm))
         for v in result.values():
             self.assertIs(v, True)
 
@@ -324,48 +325,46 @@ class TestGetEastAsianWidth(TestCase):
 
 
 class TestExamenUnicode(TestCase):
-    """examen_unicode builds per-character attribute list."""
-    REQUIRED_KEYS = {'char', 'name', 'category', 'digit', 'bidi', 'ord', 'code_point', 'hex'}
-
+    """examen_unicode builds per-character CharacterInfo list."""
     def test_empty_string(self):
         """Empty string returns empty list."""
         self.assertEqual(u.examen_unicode(''), [])
 
     def test_single_character(self):
-        """Single character returns one dict with all required keys."""
+        """Single character returns one CharacterInfo with all attributes."""
         result = u.examen_unicode('A')
         self.assertEqual(len(result), 1)
-        self.assertEqual(set(result[0].keys()), self.REQUIRED_KEYS)
-        self.assertEqual(result[0]['char'], 'A')
-        self.assertEqual(result[0]['ord'], 65)
-        self.assertEqual(result[0]['code_point'], 'U+0041')
-        self.assertEqual(result[0]['hex'], '0041')
+        self.assertIsInstance(result[0], u.CharacterInfo)
+        self.assertEqual(result[0].char, 'A')
+        self.assertEqual(result[0].ord, 65)
+        self.assertEqual(result[0].code_point, 'U+0041')
+        self.assertEqual(result[0].hex, '0041')
 
     def test_multiple_characters(self):
-        """Multiple characters return one dict per character."""
+        """Multiple characters return one CharacterInfo per character."""
         result = u.examen_unicode('Hi')
         self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]['char'], 'H')
-        self.assertEqual(result[1]['char'], 'i')
+        self.assertEqual(result[0].char, 'H')
+        self.assertEqual(result[1].char, 'i')
 
     def test_unicode_string(self):
         """Non-ASCII and emoji are handled."""
         result = u.examen_unicode('😀')
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]['char'], '😀')
-        self.assertEqual(result[0]['code_point'], 'U+1F600')
+        self.assertEqual(result[0].char, '😀')
+        self.assertEqual(result[0].code_point, 'U+1F600')
 
 
 class TestAlias(TestCase):
     """Alias lookup from NameAliases.txt."""
-    def test_get_aliases_list(self):
-        """get_aliases with format=False returns a list."""
-        aliases = u.alias.get_aliases('A', format=False)
+    def test_get_aliases_returns_list(self):
+        """get_aliases returns a list of alias strings."""
+        aliases = u.alias.get_aliases('A')
         self.assertIsInstance(aliases, list)
 
-    def test_get_aliases_formatted(self):
-        """get_aliases with format=True returns comma-separated string."""
-        result = u.alias.get_aliases('A', format=True)
+    def test_get_aliases_can_be_joined(self):
+        """Callers can format aliases manually, e.g. ', '.join(get_aliases(char))."""
+        result = ', '.join(u.alias.get_aliases('A'))
         self.assertIsInstance(result, str)
 
     def test_get_alias_returns_string(self):

--- a/tests.py
+++ b/tests.py
@@ -264,19 +264,19 @@ class TestUnicodeDigits(TestCase):
     def setUp(self):
         self.digits = {
             '1': 1,      # U+0031 DIGIT ONE
-            '⑩': '',     # U+2469 CIRCLED NUMBER TEN (digit may be 10 or not defined)
+            '⑩': None,  # U+2469 CIRCLED NUMBER TEN (digit may be 10 or not defined)
             '۵': 5,      # U+06F5 EXTENDED ARABIC-INDIC DIGIT FIVE
             '६': 6,      # U+096C DEVANAGARI DIGIT SIX
             '੧': 1,      # U+0A67 GURMUKHI DIGIT ONE
-            '🔟': '',    # U+1F51F KEYCAP TEN
+            '🔟': None,  # U+1F51F KEYCAP TEN
             '૫': 5,      # U+0AEB GUJARATI DIGIT FIVE
-            'Ⅶ': '',     # U+2166 ROMAN NUMERAL SEVEN
+            'Ⅶ': None,  # U+2166 ROMAN NUMERAL SEVEN
             '¹': 1,      # U+00B9 SUPERSCRIPT ONE
-            'H': '',     # U+0048 LATIN CAPITAL LETTER H
+            'H': None,   # U+0048 LATIN CAPITAL LETTER H
         }
 
     def test_digit(self):
-        """get_digit returns numeric value or empty string."""
+        """get_digit returns numeric value or None for non-digit."""
         for char, expected in self.digits.items():
             with self.subTest(char=repr(char), expected=expected):
                 self.assertEqual(u.get_digit(char), expected)
@@ -317,22 +317,30 @@ class TestGetDirection(TestCase):
     def test_rtl(self):
         self.assertEqual(u.get_direction('א'), 'RIGHT-TO-LEFT (NON-ARABIC)')
 
-    def test_returns_string(self):
-        """get_direction always returns a string (possibly empty)."""
+    def test_returns_string_or_none(self):
+        """get_direction returns str or None."""
         self.assertIsInstance(u.get_direction('A'), str)
-        self.assertIsInstance(u.get_direction(' '), str)
+        result = u.get_direction(' ')
+        self.assertTrue(result is None or isinstance(result, str))
 
 
 class TestGetEastAsianWidth(TestCase):
     """East Asian width category."""
-    def test_returns_string(self):
-        self.assertIsInstance(u.get_east_asian_width('A'), str)
-        self.assertIsInstance(u.get_east_asian_width('　'), str)
+    def test_returns_string_or_none(self):
+        """get_east_asian_width returns str or None."""
+        result = u.get_east_asian_width('A')
+        self.assertTrue(result is None or isinstance(result, str))
+        result = u.get_east_asian_width('　')
+        self.assertTrue(result is None or isinstance(result, str))
 
     def test_known_categories(self):
         """Common characters have a non-empty width label."""
-        self.assertTrue(len(u.get_east_asian_width('A')) > 0)
-        self.assertTrue(len(u.get_east_asian_width('あ')) > 0)
+        result_a = u.get_east_asian_width('A')
+        self.assertIsNotNone(result_a)
+        self.assertGreater(len(result_a), 0)
+        result_ja = u.get_east_asian_width('あ')
+        self.assertIsNotNone(result_ja)
+        self.assertGreater(len(result_ja), 0)
 
 
 class TestExamenUnicode(TestCase):
@@ -409,7 +417,7 @@ class TestGetCharacterPageDescription(TestCase):
         self.assertEqual(desc['lower'], 'a')
         self.assertIsInstance(desc['decomposition'], str)
         self.assertIsInstance(desc['aliases'], str)
-        self.assertIsInstance(desc['east_asian'], str)
+        self.assertTrue(desc['east_asian'] is None or isinstance(desc['east_asian'], str))
 
 
 class DecodeViewTestCase(TestCase):

--- a/unicode_util.py
+++ b/unicode_util.py
@@ -98,12 +98,17 @@ def get_code_point(char: str, prefix: bool = True) -> str:
     """Format the character's code point as hex.
 
     Args:
-        char: Single Unicode character.
+        char: Single Unicode character (must be length 1).
         prefix: If True, include 'U+' prefix (e.g. 'U+0061'); else bare hex.
 
     Returns:
         Code point as string, e.g. 'U+0061' or '0061'.
+
+    Raises:
+        ValueError: If char is not exactly one character.
     """
+    if len(char) != 1:
+        raise ValueError(f"get_code_point expects a single character, got length {len(char)}")
     if prefix:
         return f'U+{ord(char):04X}'
     return f'{ord(char):04X}'

--- a/unicode_util.py
+++ b/unicode_util.py
@@ -20,10 +20,10 @@ _APP_DIR: str = os.path.dirname(os.path.abspath(__file__))
 class NormalizationForm(str, Enum):
     """Unicode normalization form."""
 
-    NFC = 'NFC'
-    NFKC = 'NFKC'
-    NFD = 'NFD'
-    NFKD = 'NFKD'
+    NFC = 'NFC'  # Canonical Composition
+    NFKC = 'NFKC'  # Compatibility Composition
+    NFD = 'NFD'  # Canonical Decomposition
+    NFKD = 'NFKD'  # Compatibility Decomposition
 
 
 @dataclass

--- a/unicode_util.py
+++ b/unicode_util.py
@@ -232,29 +232,46 @@ def get_east_asian_width(char: str) -> Optional[str]:
     except (ValueError, TypeError):
         return None
 
-def get_character_page_description(char: str) -> Dict[str, Any]:
-    """Build a dict of character attributes for a detail/codepoint page.
+@dataclass
+class CodepointDescription:
+    """Character attributes for the codepoint detail page."""
+
+    title: str
+    tagline: str
+    char: str
+    name: str
+    category: str
+    digit: Optional[int]
+    direction: Optional[str]
+    integer: int
+    upper: str
+    lower: str
+    decomposition: str
+    aliases: str
+    east_asian: Optional[str]
+
+
+def get_character_page_description(char: str) -> CodepointDescription:
+    """Build character attributes for a detail/codepoint page.
 
     Args:
         char: Single Unicode character.
 
     Returns:
-        Dict with 'title', 'tagline', 'char', 'name', 'category', 'digit',
-        'direction', 'integer', 'upper', 'lower', 'decomposition', 'aliases',
-        and 'east_asian'.
+        CodepointDescription with all fields for the codepoint template.
     """
-    return {
-        'title' : get_name(char),
-        'tagline' : get_code_point(char),
-        'char' : char,
-        'name' : get_name(char),
-        'category' : get_category(char),
-        'digit': get_digit(char),
-        'direction': get_direction(char),
-        'integer': ord(char),
-        'upper': char.upper(),
-        'lower' : char.lower(),
-        'decomposition': ud.decomposition(char),
-        'aliases': ', '.join(alias.get_aliases(char)),
-        'east_asian': get_east_asian_width(char),
-    }
+    return CodepointDescription(
+        title=get_name(char),
+        tagline=get_code_point(char),
+        char=char,
+        name=get_name(char),
+        category=get_category(char),
+        digit=get_digit(char),
+        direction=get_direction(char),
+        integer=ord(char),
+        upper=char.upper(),
+        lower=char.lower(),
+        decomposition=ud.decomposition(char),
+        aliases=', '.join(alias.get_aliases(char)),
+        east_asian=get_east_asian_width(char),
+    )

--- a/unicode_util.py
+++ b/unicode_util.py
@@ -35,9 +35,9 @@ class CharacterInfo:
     category: str
     digit: Union[int, str]
     bidi: str
-    ord: int  # noqa: A001
+    ordinal: int
     code_point: str
-    hex: str  # noqa: A001
+    hex_code: str
 
 
 def examen_unicode(text: str) -> List[CharacterInfo]:
@@ -56,9 +56,9 @@ def examen_unicode(text: str) -> List[CharacterInfo]:
             category=get_category(char),
             digit=get_digit(char),
             bidi=get_direction(char),
-            ord=ord(char),
+            ordinal=ord(char),
             code_point=get_code_point(char),
-            hex=get_code_point(char, False),
+            hex_code=get_code_point(char, False),
         )
         for char in text
     ]

--- a/unicode_util.py
+++ b/unicode_util.py
@@ -6,75 +6,95 @@ bidirectional class, East Asian width, and aliases from the Unicode database.
 
 import os
 import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Union
+
 import unicodedata2 as ud
 from decode.mappings import bidi, category, east_asian_categories
 
 # App package directory (decode/)
-_APP_DIR = os.path.dirname(os.path.abspath(__file__))
+_APP_DIR: str = os.path.dirname(os.path.abspath(__file__))
 
-def examen_unicode(text):
-    """Build a list of per-character attribute dicts for the given text.
+
+class NormalizationForm(str, Enum):
+    """Unicode normalization form."""
+
+    NFC = 'NFC'
+    NFKC = 'NFKC'
+    NFD = 'NFD'
+    NFKD = 'NFKD'
+
+
+@dataclass
+class CharacterInfo:
+    """Per-character Unicode attributes from examen_unicode."""
+
+    char: str
+    name: str
+    category: str
+    digit: Union[int, str]
+    bidi: str
+    ord: int  # noqa: A001
+    code_point: str
+    hex: str  # noqa: A001
+
+
+def examen_unicode(text: str) -> list[CharacterInfo]:
+    """Build a list of per-character attribute objects for the given text.
 
     Args:
         text: String of Unicode characters to inspect.
 
     Returns:
-        List of dicts, one per character, with keys such as 'char', 'name',
-        'category', 'digit', 'bidi', 'ord', 'code_point', and 'hex'.
+        List of CharacterInfo, one per character.
     """
-    char_list = []
-    for char in text:
-        char_dict = {
-            'char' : char,
-            'name' : get_name(char),
-            'category' : get_category(char),
-            'digit' : get_digit(char),
-            'bidi' : get_direction(char),
-            'ord' : ord(char),
-            'code_point' : get_code_point(char),
-            'hex' : get_code_point(char, False),
-        }
-
-        char_list.append(char_dict)
-    return char_list
+    return [
+        CharacterInfo(
+            char=char,
+            name=get_name(char),
+            category=get_category(char),
+            digit=get_digit(char),
+            bidi=get_direction(char),
+            ord=ord(char),
+            code_point=get_code_point(char),
+            hex=get_code_point(char, False),
+        )
+        for char in text
+    ]
 
 
 
-def is_normalized(form, s):
+def is_normalized(form: NormalizationForm, s: str) -> bool:
     """Return whether the string is already in the given normalization form.
 
     Args:
-        form: Unicode normalization form name ('NFC', 'NFKC', 'NFD', or 'NFKD').
+        form: Unicode normalization form (NFC, NFKC, NFD, or NFKD).
         s: Unicode string to check.
 
     Returns:
         True if s is normalized in that form, False otherwise.
     """
-    return s == ud.normalize(form, s)
+    return s == ud.normalize(form.value, s)
 
 
-def get_normalization_form(string):
+def get_normalization_form(string: str) -> dict[NormalizationForm, bool]:
     """Report which Unicode normalization forms the string is already in.
 
     Args:
         string: Unicode string to check.
 
     Returns:
-        Dict mapping form name ('NFC', 'NFKC', 'NFD', 'NFKD') to True if
-        the string is normalized in that form, else False.
+        Dict mapping each normalization form to True if the string is
+        normalized in that form, else False.
     """
-    forms = ['NFC', 'NFKC', 'NFD', 'NFKD']
-    normalization_form = {}
-
-    for form in forms:
-        if is_normalized(form, string):
-            normalization_form[form] = True
-        else:
-            normalization_form[form] = False
+    normalization_form: dict[NormalizationForm, bool] = {}
+    for form in NormalizationForm:
+        normalization_form[form] = is_normalized(form, string)
     return normalization_form
 
 
-def get_code_point(char, prefix=True):
+def get_code_point(char: str, prefix: bool = True) -> str:
     """Format the character's code point as hex.
 
     Args:
@@ -92,31 +112,27 @@ def get_code_point(char, prefix=True):
 class Alias:
     """Look up formal name aliases for Unicode characters from NameAliases.txt."""
 
-    def __init__(self):
+    raw: str
+
+    def __init__(self) -> None:
         """Load NameAliases.txt from the package files directory."""
         with open(os.path.join(_APP_DIR, 'files', 'NameAliases.txt'), encoding='utf-8') as f:
             self.raw = f.read()
 
-
-    def get_aliases(self, char, format=False):
+    def get_aliases(self, char: str) -> list[str]:
         """Return formal name aliases for the character.
 
         Args:
             char: Single Unicode character.
-            format: If True, return a single comma-separated string; else list.
 
         Returns:
-            List of alias strings, or comma-separated string if format is True.
+            List of alias strings.
         """
-        code_point = get_code_point(char, False)
-        pattern = f'{code_point};([A-Z ]+);'
-        aliases = re.findall(pattern, self.raw, re.IGNORECASE)
+        code_point: str = get_code_point(char, False)
+        pattern: str = f'{code_point};([A-Z ]+);'
+        return re.findall(pattern, self.raw, re.IGNORECASE)
 
-        if format:
-            return ', '.join(aliases)
-        return aliases
-
-    def get_alias(self, char):
+    def get_alias(self, char: str) -> str:
         """Return the first formal name alias for the character, or 'UNKNOWN'.
 
         Args:
@@ -125,17 +141,17 @@ class Alias:
         Returns:
             First alias string, or 'UNKNOWN' if none are found.
         """
-        aliases = self.get_aliases(char)
+        aliases: list[str] = self.get_aliases(char)
 
         if aliases:
             return aliases[0]
         return "UNKNOWN"
 
 
-alias = Alias()
+alias: Alias = Alias()
 
 
-def get_name(char):
+def get_name(char: str) -> str:
     """Return the Unicode character name, or first alias if no name is defined.
 
     Args:
@@ -145,12 +161,12 @@ def get_name(char):
         Official name or first alias string.
     """
     try:
-        name = ud.name(char)
+        name: str = ud.name(char)
     except ValueError:
         name = alias.get_alias(char)
     return name
 
-def get_category(char):
+def get_category(char: str) -> str:
     """Return a human-readable character general category.
 
     Args:
@@ -165,7 +181,7 @@ def get_category(char):
         return ''
 
 
-def get_digit(char):
+def get_digit(char: str) -> Union[int, str]:
     """Return the digit value for numeric characters.
 
     Args:
@@ -180,7 +196,7 @@ def get_digit(char):
         return ''
 
 
-def get_direction(char):
+def get_direction(char: str) -> str:
     """Return the character's bidirectional class label.
 
     Args:
@@ -195,7 +211,7 @@ def get_direction(char):
         return ''
 
 
-def get_east_asian_width(char):
+def get_east_asian_width(char: str) -> str:
     """Return the East Asian width category for the character.
 
     Args:
@@ -206,12 +222,12 @@ def get_east_asian_width(char):
         or '' on invalid input.
     """
     try:
-        width = ud.east_asian_width(char)
+        width: str = ud.east_asian_width(char)
         return east_asian_categories.get(width, width)
     except (ValueError, TypeError):
         return ''
 
-def get_character_page_description(char):
+def get_character_page_description(char: str) -> dict[str, Any]:
     """Build a dict of character attributes for a detail/codepoint page.
 
     Args:
@@ -234,6 +250,6 @@ def get_character_page_description(char):
         'upper': char.upper(),
         'lower' : char.lower(),
         'decomposition': ud.decomposition(char),
-        'aliases': alias.get_aliases(char, True),
+        'aliases': ', '.join(alias.get_aliases(char)),
         'east_asian': get_east_asian_width(char),
     }

--- a/unicode_util.py
+++ b/unicode_util.py
@@ -32,7 +32,7 @@ class CharacterInfo:
 
     char: str
     name: str
-    category: str
+    category: Optional[str]
     digit: Optional[int]
     bidi: Optional[str]
     ordinal: int
@@ -171,19 +171,19 @@ def get_name(char: str) -> str:
         name = alias.get_alias(char)
     return name
 
-def get_category(char: str) -> str:
+def get_category(char: str) -> Optional[str]:
     """Return a human-readable character general category.
 
     Args:
         char: Single Unicode character.
 
     Returns:
-        Category label string (e.g. 'UPPERCASE LETTER'), or '' if unknown.
+        Category label string (e.g. 'UPPERCASE LETTER'), or None if unknown.
     """
     try:
         return category[ud.category(char)]
     except KeyError:
-        return ''
+        return None
 
 
 def get_digit(char: str) -> Optional[int]:
@@ -240,7 +240,7 @@ class CodepointDescription:
     tagline: str
     char: str
     name: str
-    category: str
+    category: Optional[str]
     digit: Optional[int]
     direction: Optional[str]
     integer: int

--- a/unicode_util.py
+++ b/unicode_util.py
@@ -8,7 +8,7 @@ import os
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import unicodedata2 as ud
 from decode.mappings import bidi, category, east_asian_categories
@@ -33,8 +33,8 @@ class CharacterInfo:
     char: str
     name: str
     category: str
-    digit: Union[int, str]
-    bidi: str
+    digit: Optional[int]
+    bidi: Optional[str]
     ordinal: int
     code_point: str
     hex_code: str
@@ -186,37 +186,37 @@ def get_category(char: str) -> str:
         return ''
 
 
-def get_digit(char: str) -> Union[int, str]:
+def get_digit(char: str) -> Optional[int]:
     """Return the digit value for numeric characters.
 
     Args:
         char: Single Unicode character.
 
     Returns:
-        Digit value (e.g. 0-9 for decimal digits), or '' if not a digit.
+        Digit value (e.g. 0-9 for decimal digits), or None if not a digit.
     """
     try:
-        return ud.digit(char, '')
+        return ud.digit(char)
     except (ValueError, TypeError):
-        return ''
+        return None
 
 
-def get_direction(char: str) -> str:
+def get_direction(char: str) -> Optional[str]:
     """Return the character's bidirectional class label.
 
     Args:
         char: Single Unicode character.
 
     Returns:
-        Bidi class string (e.g. 'LEFT-TO-RIGHT'), or '' if not in our mapping.
+        Bidi class string (e.g. 'LEFT-TO-RIGHT'), or None if not in our mapping.
     """
     try:
         return bidi[ud.bidirectional(char)]
     except KeyError:
-        return ''
+        return None
 
 
-def get_east_asian_width(char: str) -> str:
+def get_east_asian_width(char: str) -> Optional[str]:
     """Return the East Asian width category for the character.
 
     Args:
@@ -224,13 +224,13 @@ def get_east_asian_width(char: str) -> str:
 
     Returns:
         Width label (e.g. 'East Asian Fullwidth') or raw property value,
-        or '' on invalid input.
+        or None on invalid input.
     """
     try:
         width: str = ud.east_asian_width(char)
         return east_asian_categories.get(width, width)
     except (ValueError, TypeError):
-        return ''
+        return None
 
 def get_character_page_description(char: str) -> Dict[str, Any]:
     """Build a dict of character attributes for a detail/codepoint page.

--- a/unicode_util.py
+++ b/unicode_util.py
@@ -8,7 +8,7 @@ import os
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Union
+from typing import Any, Dict, List, Union
 
 import unicodedata2 as ud
 from decode.mappings import bidi, category, east_asian_categories
@@ -40,7 +40,7 @@ class CharacterInfo:
     hex: str  # noqa: A001
 
 
-def examen_unicode(text: str) -> list[CharacterInfo]:
+def examen_unicode(text: str) -> List[CharacterInfo]:
     """Build a list of per-character attribute objects for the given text.
 
     Args:
@@ -78,7 +78,7 @@ def is_normalized(form: NormalizationForm, s: str) -> bool:
     return s == ud.normalize(form.value, s)
 
 
-def get_normalization_form(string: str) -> dict[NormalizationForm, bool]:
+def get_normalization_form(string: str) -> Dict[NormalizationForm, bool]:
     """Report which Unicode normalization forms the string is already in.
 
     Args:
@@ -88,9 +88,9 @@ def get_normalization_form(string: str) -> dict[NormalizationForm, bool]:
         Dict mapping each normalization form to True if the string is
         normalized in that form, else False.
     """
-    normalization_form: dict[NormalizationForm, bool] = {}
+    normalization_form: Dict[NormalizationForm, bool] = {}
     for form in NormalizationForm:
-        normalization_form[form] = is_normalized(form, string)
+        normalization_form[form.name] = is_normalized(form, string)
     return normalization_form
 
 
@@ -119,7 +119,7 @@ class Alias:
         with open(os.path.join(_APP_DIR, 'files', 'NameAliases.txt'), encoding='utf-8') as f:
             self.raw = f.read()
 
-    def get_aliases(self, char: str) -> list[str]:
+    def get_aliases(self, char: str) -> List[str]:
         """Return formal name aliases for the character.
 
         Args:
@@ -141,7 +141,7 @@ class Alias:
         Returns:
             First alias string, or 'UNKNOWN' if none are found.
         """
-        aliases: list[str] = self.get_aliases(char)
+        aliases: List[str] = self.get_aliases(char)
 
         if aliases:
             return aliases[0]
@@ -227,7 +227,7 @@ def get_east_asian_width(char: str) -> str:
     except (ValueError, TypeError):
         return ''
 
-def get_character_page_description(char: str) -> dict[str, Any]:
+def get_character_page_description(char: str) -> Dict[str, Any]:
     """Build a dict of character attributes for a detail/codepoint page.
 
     Args:

--- a/unicode_util.py
+++ b/unicode_util.py
@@ -90,7 +90,7 @@ def get_normalization_form(string: str) -> Dict[NormalizationForm, bool]:
     """
     normalization_form: Dict[NormalizationForm, bool] = {}
     for form in NormalizationForm:
-        normalization_form[form.name] = is_normalized(form, string)
+        normalization_form[form] = is_normalized(form, string)
     return normalization_form
 
 
@@ -170,6 +170,7 @@ def get_name(char: str) -> str:
     except ValueError:
         name = alias.get_alias(char)
     return name
+
 
 def get_category(char: str) -> Optional[str]:
     """Return a human-readable character general category.

--- a/views.py
+++ b/views.py
@@ -4,6 +4,7 @@ Handles rendering of the about, codepoint, decode, privacy, terms, and tofu
 pages, and processes Unicode text decoding form submissions.
 """
 
+from dataclasses import asdict
 from django.shortcuts import render
 from decode.forms import UnicodeTextForm
 import decode.unicode_util as u
@@ -31,7 +32,7 @@ def codepoint(request, slug):
     """
     char = chr(int(slug, 16))
     char_desc = u.get_character_page_description(char)
-    return render(request, 'decode/codepoint.html', char_desc)
+    return render(request, 'decode/codepoint.html', asdict(char_desc))
 
 
 def privacy(request):


### PR DESCRIPTION
Code clean up to follow better practices.

* Move to python to 3.14.3
* Add mypy type annotations
* Refactor transformation classes to use Dataclasses
* Enum for Normalization Forms